### PR TITLE
Extend functionality by freezing [NSDate timeIntervalSinceReferenceDate] when necessary

### DIFF
--- a/Classes/common/TUDelorean.h
+++ b/Classes/common/TUDelorean.h
@@ -149,6 +149,16 @@ typedef void(^TUDeloreanBlock)(NSDate *date);
 /** @name Freeze time */
 
 /**
+ * Freezes the time at the actual date.
+ *
+ * The time will change to the actual date and will not advance at all.
+ *
+ * The effects of this time freeze will affect the current time until another
+ * time operation is performed.
+ */
++ (void)freeze;
+
+/**
  * Freezes the time at the given date.
  *
  * The time will change to the given date and will not advance at all.

--- a/Classes/common/TUDelorean.m
+++ b/Classes/common/TUDelorean.m
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 
 + (instancetype)delorean_date;
 + (instancetype)delorean_dateWithTimeIntervalSinceNow:(NSTimeInterval)secs;
++ (NSTimeInterval)delorean_timeIntervalSinceReferenceDate;
 
 - (instancetype)delorean_init __attribute__((objc_method_family(init)));
 - (instancetype)delorean_initWithTimeIntervalSinceNow:(NSTimeInterval)secs  __attribute__((objc_method_family(init)));
@@ -114,6 +115,11 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 + (void)jump:(NSTimeInterval)timeInterval block:(TUDeloreanBlock)block
 {
 	[[self sharedDelorean] jump:timeInterval block:block];
+}
+
++ (void)freeze
+{
+	[self freeze:[NSDate date]];
 }
 
 + (void)freeze:(NSDate *)date
@@ -233,6 +239,9 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 	TUSwizzleClassMethods(dateClass,
 						  @selector(dateWithTimeIntervalSinceNow:),
 						  @selector(delorean_dateWithTimeIntervalSinceNow:));
+	TUSwizzleClassMethods(dateClass,
+						  @selector(timeIntervalSinceReferenceDate),
+						  @selector(delorean_timeIntervalSinceReferenceDate));
 }
 
 @end
@@ -286,6 +295,19 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 + (instancetype)delorean_dateWithTimeIntervalSinceNow:(NSTimeInterval)secs
 {
 	return [[self alloc] initWithTimeIntervalSinceNow:secs];
+}
+
++ (NSTimeInterval)delorean_timeIntervalSinceReferenceDate
+{
+	TUTimeJump *timeJump = [[TUDelorean sharedDelorean] topTimeJump];
+	if (timeJump != nil)
+	{
+		return [[timeJump now] timeIntervalSinceReferenceDate];
+	}
+	else
+	{
+		return [self delorean_timeIntervalSinceReferenceDate];
+	}
 }
 
 - (instancetype)delorean_init

--- a/LICENSE
+++ b/LICENSE
@@ -175,28 +175,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/Project/common/TUDeloreanTest.m
+++ b/Project/common/TUDeloreanTest.m
@@ -193,6 +193,7 @@
 {
 	[TUDelorean freeze:_enchantmentUnderTheSeaDance];
 	STAssertEqualObjects([NSDate date], _enchantmentUnderTheSeaDance, @"now should be exactly the Enchantment Under The See Dance");
+	STAssertEquals([NSDate timeIntervalSinceReferenceDate], [_enchantmentUnderTheSeaDance timeIntervalSinceReferenceDate], @"time interval since reference date should be exactly same as for the Enchantment Under The See Dance");
 }
 
 - (void)test_freeze_should_kept_the_last_frozen_time
@@ -200,6 +201,7 @@
 	[TUDelorean freeze:_enchantmentUnderTheSeaDance];
 	[TUDelorean freeze:_clockTowerInauguration];
 	STAssertEqualObjects([NSDate date], _clockTowerInauguration, @"now should be exactly the Clock Tower Inauguration");
+	STAssertEquals([NSDate timeIntervalSinceReferenceDate], [_clockTowerInauguration timeIntervalSinceReferenceDate], @"time interval since reference date should be exactly same as for the Clock Tower Inauguration");
 }
 
 - (void)test_freezeBlock_should_travel_back_in_time


### PR DESCRIPTION
- Swizzle [NSDate timeIntervalSinceReferenceDate] so that it returns a value depending on a time jump if available. If not it will work as normally.
- Removed unnecessary appendix from license file.
