### PR TITLE
Added assert to avoid setting nil date value when using TUDelorean

### DIFF
--- a/Classes/common/TUDelorean.m
+++ b/Classes/common/TUDelorean.m
@@ -251,6 +251,7 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 
 - (instancetype)initWithType:(TUTimeJumpType)type date:(NSDate *)date
 {
+	NSAssert(date, @"Can't create a time jump with a nil date");
 	if ((self = [super init]))
 	{
 		_type = type;

--- a/Classes/common/TUDelorean.m
+++ b/Classes/common/TUDelorean.m
@@ -251,7 +251,7 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 
 - (instancetype)initWithType:(TUTimeJumpType)type date:(NSDate *)date
 {
-	NSAssert(date, @"Can't create a time jump with a nil date");
+    NSParameterAssert(date != nil);
 	if ((self = [super init]))
 	{
 		_type = type;

--- a/Classes/common/TUDelorean.m
+++ b/Classes/common/TUDelorean.m
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 @property (nonatomic, strong, readonly) NSDate *date;
 @property (nonatomic, assign, readonly) NSTimeInterval offset;
 
-- (id)initWithType:(TUTimeJumpType)type date:(NSDate *)date;
+- (instancetype)initWithType:(TUTimeJumpType)type date:(NSDate *)date;
 
 - (NSDate *)now;
 
@@ -137,7 +137,7 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 	[[self sharedDelorean] backToThePresent];
 }
 
-- (id)init
+- (instancetype)init
 {
 	if ((self = [super init]))
 	{
@@ -249,7 +249,7 @@ typedef NS_ENUM(NSUInteger, TUTimeJumpType)
 
 @implementation TUTimeJump
 
-- (id)initWithType:(TUTimeJumpType)type date:(NSDate *)date
+- (instancetype)initWithType:(TUTimeJumpType)type date:(NSDate *)date
 {
 	if ((self = [super init]))
 	{


### PR DESCRIPTION
Added a parameter assert to the initWithType:date: method from TUTimeJump
to make it fail when a nil date is passed as argument
